### PR TITLE
Code server with istio

### DIFF
--- a/code_server_istio_vs.yaml
+++ b/code_server_istio_vs.yaml
@@ -40,9 +40,9 @@ spec:
   - name: code-server-http
     match:
     - uri:
-        exact: /
-#    rewrite:
-#      uri: /
+        exact: /code-server
+    rewrite:
+      uri: /
     route:
     - destination:
         host: code-server-service

--- a/code_server_istio_vs.yaml
+++ b/code_server_istio_vs.yaml
@@ -1,3 +1,6 @@
+# this uses istio VirtualService and Gateway.
+# Work-in-progress
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/code_server_istio_vs.yaml
+++ b/code_server_istio_vs.yaml
@@ -39,10 +39,10 @@ spec:
   http:
   - name: code-server-http
     match:
-    - uri:
-        exact: /code-server
-    rewrite:
-      uri: /
+    - uri:   # for initial GET to code-server
+        exact: /
+    - uri:  # this needed to handle internal back and forth w/ browser
+        regex: /*
     route:
     - destination:
         host: code-server-service
@@ -110,6 +110,7 @@ spec:
       - image: codercom/code-server:latest
         imagePullPolicy: Always
         name: code-server
+        args: ["--bind-addr", "0.0.0.0:8080", "--auth", "none"]
         env:
         - name: PASSWORD
           value: "your_password"

--- a/code_server_istio_vs.yaml
+++ b/code_server_istio_vs.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-server
+  labels:
+    istio-injection: enabled
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: code-server-gateway
+  namespace: code-server
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: code-server-vs
+  namespace: code-server
+spec:
+  gateways:
+  - code-server-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        exact: /code-server
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: code-server-service
+        port:
+          number: 80
+    timeout: 300s
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: code-server-login-vs
+  namespace: code-server
+spec:
+  gateways:
+  - code-server-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /login
+    route:
+    - destination:
+        host: code-server-service
+        port:
+          number: 80
+
+    timeout: 300s
+
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: echo-vs
+  namespace: code-server
+spec:
+  gateways:
+  - code-server-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        exact: /code-server/echo
+    rewrite:
+      uri: /echo
+    route:
+    - destination:
+        host: echo-service
+        port:
+          number: 5678
+    timeout: 300s
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+ name: code-server-service
+ namespace: code-server
+spec:
+ ports:
+ - port: 80
+   name: http
+   targetPort: 8080
+ selector:
+   app: code-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: code-server
+  name: code-server
+  namespace: code-server
+spec:
+  selector:
+    matchLabels:
+      app: code-server
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: code-server
+    spec:
+      containers:
+      - image: codercom/code-server:latest
+        imagePullPolicy: Always
+        name: code-server
+        env:
+        - name: PASSWORD
+          value: "your_password"
+        ports:
+          - containerPort: 8080
+
+---
+#
+# Demonstration echo service
+#
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: echo-app
+  namespace: code-server
+  labels:
+    app: echo
+spec:
+  containers:
+    - name: echo-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=code-server"
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: echo-service
+  namespace: code-server
+spec:
+  selector:
+    app: echo
+  ports:
+    - port: 5678 # Default port for image
+      name: http

--- a/code_server_istio_vs.yaml
+++ b/code_server_istio_vs.yaml
@@ -33,46 +33,22 @@ metadata:
   namespace: code-server
 spec:
   gateways:
-  - code-server-gateway
+    - code-server-gateway
   hosts:
-  - '*'
+    - '*'
   http:
-  - match:
+  - name: code-server-http
+    match:
     - uri:
-        exact: /code-server
-    rewrite:
-      uri: /
+        exact: /
+#    rewrite:
+#      uri: /
     route:
     - destination:
         host: code-server-service
         port:
           number: 80
     timeout: 300s
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: code-server-login-vs
-  namespace: code-server
-spec:
-  gateways:
-  - code-server-gateway
-  hosts:
-  - '*'
-  http:
-  - match:
-    - uri:
-        prefix: /login
-    route:
-    - destination:
-        host: code-server-service
-        port:
-          number: 80
-
-    timeout: 300s
-
 
 ---
 

--- a/ingress_istio_demo.yaml
+++ b/ingress_istio_demo.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-demo
+  labels:
+    istio-injection: enabled
 
 ---
 
@@ -31,6 +33,7 @@ spec:
     app: apple
   ports:
     - port: 5678 # Default port for image
+      name: http
 
 ---
 
@@ -60,6 +63,7 @@ spec:
     app: banana
   ports:
     - port: 5678 # Default port for image
+      name: http
 
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/istio_setup.sh
+++ b/istio_setup.sh
@@ -6,6 +6,10 @@ istioctl install --set profile=demo
 # specify istio to automatically inject sidecar proxies
 kubectl label namespace default istio-injection=enabled
 
+# these are for user defined demos
+kubectl label namespace code-server istio-injection=enabled
+kubectl label namespace istio-demo istio-injection=enabled
+
 # deploy BookInfo sample application
 # set working directory to istio install location
 kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml


### PR DESCRIPTION
First working version with istio.  Couple of limitations:
* Still have to use null api command to get to code-server, e.g., `http://<hostname>/` Still not sure how to specify re-write to support initial call `http://<hostname>/code-server` and the subsequent internal REST APIs to code-server
* To solve redirect issue, disabled the out-of-box use of custom password.  Used custom args when starting the code-server container